### PR TITLE
Add prep_commands

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/helpers/mocks"]
+	path = tests/helpers/mocks
+	url = https://github.com/jasonkarns/bats-mock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: shell
 script:
-  - bash -c 'shopt -s globstar; shellcheck -e SC2068 hooks/*'
+  - bash -c 'shopt -s globstar; shellcheck -e SC2068 -e SC2178 hooks/*'
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ steps:
           load_artifacts:
             - "build/artifact.zip"
             - "log/file.txt"
+          prep_commands:
+            - unzip build/artifact.zip
+            - cp /dev/null log/file.txt
 ```
 
 ## Configuration
@@ -33,6 +36,9 @@ Path within repo to packer template
 
 ### load\_artifacts
 (Optional) List of paths to artifacts to load into environment
+
+### prep\_commands
+(Optional) List of commands to run against the local repo before executing packer
 
 ## License
 MIT ([LICENSE](LICENSE))

--- a/hooks/command
+++ b/hooks/command
@@ -56,7 +56,7 @@ done
 
 # explicit delcare required, because the array element count in the if predicate below
 # generates an unbound variable error when the array is empty and 'set -u' is in play
-declare -A prep_commands
+declare -a prep_commands
 prep_commands=$(plugin_read_list PREP_COMMANDS)
 if [ "${#prep_commands[@]}" -ne 0 ]; then
   echo "--- Executing Prep Commands"

--- a/hooks/command
+++ b/hooks/command
@@ -38,7 +38,7 @@ if [ ! -f "${template[0]}" ]; then
 fi
 
 # Validate packer commands
-cmds="$(plugin_read_list PACKER_COMMANDS)"
+cmds=$(plugin_read_list PACKER_COMMANDS)
 for cmd in ${cmds[@]}; do
   if [[ ! "${cmd}" =~ ^(build|fix|inspect|validate|version)$ ]]; then
     echo "Error: ${cmd} is not a valid packer command"
@@ -50,6 +50,20 @@ done
 artifact_paths=$(plugin_read_list LOAD_ARTIFACTS)
 for ap in ${artifact_paths[@]}; do
   buildkite-agent artifact download "${ap}" .
+done
+
+# Eval Prep commands
+
+# explicit delcare required, because the array element count in the if predicate below
+# generates an unbound variable error when the array is empty and 'set -u' is in play
+declare -A prep_commands
+prep_commands=$(plugin_read_list PREP_COMMANDS)
+if [ "${#prep_commands[@]}" -ne 0 ]; then
+  echo "--- Executing Prep Commands"
+fi
+for cmd in "${prep_commands[@]}"; do
+    echo "${cmd}"
+    eval "${cmd}"
 done
 
 # Execute packer commands

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load "$BATS_PATH/load.bash"
+load helpers/mocks/stub
 
 export PACKER_SECURITY_GROUP_ID='sg-12345'
 export PACKER_SUBNET_ID='subnet-54321'
@@ -8,6 +9,10 @@ export PACKER_SSH_INTERFACE='private-ip'
 export PACKER_IAM_INSTANCE_PROFILE='packer-builder'
 export ECR_ACCOUNT_ID=0123456789
 export DOCKER_IMAGE=packer-ami-copy
+
+setup () {
+  stub docker
+}
 
 @test "fails when template not found" {
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_TEMPLATE="doesnt/exist.json"
@@ -41,14 +46,13 @@ export DOCKER_IMAGE=packer-ami-copy
   assert_output --partial "test message 123"
 }
 
-@test "reaches end (fails with docker not found)" {
+@test "reaches end (success) {
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_TEMPLATE=$PWD/tests/test-template.json
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_0=validate
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_1=build
 
   run $PWD/hooks/command
 
-  assert_failure
-  assert_output --partial "docker: command not found"
+  assert_success
 }
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -46,7 +46,7 @@ setup () {
   assert_output --partial "test message 123"
 }
 
-@test "reaches end (success) {
+@test "reaches end (success)" {
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_TEMPLATE=$PWD/tests/test-template.json
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_0=validate
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_1=build

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -28,6 +28,19 @@ export DOCKER_IMAGE=packer-ami-copy
   assert_failure
 }
 
+@test "executes prep_commands correctly" {
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_TEMPLATE=$PWD/tests/test-template.json
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_0=validate
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_1=build
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PREP_COMMANDS_0="echo test message 123"
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PREP_COMMANDS_1="exit 1"
+
+  run $PWD/hooks/command
+
+  assert_failure
+  assert_output --partial "test message 123"
+}
+
 @test "reaches end (fails with docker not found)" {
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_TEMPLATE=$PWD/tests/test-template.json
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_0=validate
@@ -38,3 +51,4 @@ export DOCKER_IMAGE=packer-ami-copy
   assert_failure
   assert_output --partial "docker: command not found"
 }
+


### PR DESCRIPTION
Adding a `prep_commands` feature to allow people to execute commands in their repository before jumping into packer container to build the AMI.

This is required to facilitate more complex builds adapting their pipeline to use this plugin