### PR TITLE
v0.4 - add chdir parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Valid packer commands.  Either a single command, or a list of them
 ### packer\_template
 Path within repo to packer template
 
+### chdir
+(Optional) Set working directory within repo.  If specified, all paths will be relative to this.
+
 ### env\_vars
 (Optional) List of additional environment variables available to packer template
 

--- a/hooks/command
+++ b/hooks/command
@@ -30,6 +30,17 @@ for e in $(plugin_read_list ENV_VARS); do
   env_vars+=("--env ${e}")
 done
 
+# update pwd if chdir parameter is set
+chdir=$(plugin_read_list CHDIR)
+if [ ! -z "${chdir[0]}" ]; then
+  if [ -d "${chdir[0]}" ]; then
+    cd "${chdir[0]}"
+  else
+    echo "Error: chdir parameter is set, but directory doesn't exist"
+    exit 1
+  fi
+fi
+
 # Check that the template exists
 template=$(plugin_read_list PACKER_TEMPLATE)
 if [ ! -f "${template[0]}" ]; then

--- a/hooks/command
+++ b/hooks/command
@@ -32,7 +32,7 @@ done
 
 # update pwd if chdir parameter is set
 chdir=$(plugin_read_list CHDIR)
-if [ ! -z "${chdir[0]}" ]; then
+if [ -n "${chdir[0]}" ]; then
   if [ -d "${chdir[0]}" ]; then
     cd "${chdir[0]}"
   else

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,7 +12,13 @@ configuration:
         - array
     packer_template:
       type: string
+    chdir:
+      type: string
     env_vars:
+      type: array
+    load_artifacts:
+      type: array
+    prep_commands:
       type: array
   required:
     - packer_commands

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -46,6 +46,17 @@ setup () {
   assert_output --partial "test message 123"
 }
 
+@test "uses chdir parameter to change PWD correctly" {
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_TEMPLATE=test-template.json
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_0=validate
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_1=build
+  export BUILDKITE_PLUGIN_PACKER_AMI_COPY_CHDIR=tests
+
+  run $PWD/hooks/command
+
+  assert_success
+}
+
 @test "reaches end (success)" {
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_TEMPLATE=$PWD/tests/test-template.json
   export BUILDKITE_PLUGIN_PACKER_AMI_COPY_PACKER_COMMANDS_0=validate
@@ -55,4 +66,3 @@ setup () {
 
   assert_success
 }
-


### PR DESCRIPTION
chdir parameter allows user to specify a different PWD than the base of the repo.  This is helpful when working with packer templates configured with relative paths.